### PR TITLE
Fix: package.json 파일의 webpack, webpack-cli 버전 수정

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -46,8 +46,8 @@
     "husky": "3.1.0",
     "lint-staged": "^9.5.0",
     "prettier": "^2.1.2",
-    "webpack": "@4",
-    "webpack-cli": "@3",
+    "webpack": "^4.44.2",
+    "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {


### PR DESCRIPTION
두 라이브러리의 버전이 @4,@3으로 표기된 문제를 수정함.

npm 사용시 @4 처럼 사용하면 4버전의 마지막 버전으로 설치가 되었었는데 yarn에서는 다르게 동작하는것 같습니다.