### PR TITLE
Feat: CustomButton 추가, ColorStyle 추가

### DIFF
--- a/front/src/components/ColorStyle.js
+++ b/front/src/components/ColorStyle.js
@@ -5,18 +5,22 @@ const colors = {
   default: {
     background: OpenColor.white,
     color: OpenColor.gray[9],
+    borderColor: OpenColor.gray[2],
   },
   green: {
     background: OpenColor.green[7],
     color: OpenColor.white,
+    borderColor: 'transparent',
   },
   gray: {
     background: OpenColor.gray[6],
     color: OpenColor.white,
+    borderColor: 'transparent',
   },
   whiteRed: {
     background: OpenColor.white,
     color: OpenColor.red[8],
+    borderColor: OpenColor.gray[2],
   },
 };
 

--- a/front/src/components/ColorStyle.js
+++ b/front/src/components/ColorStyle.js
@@ -1,0 +1,23 @@
+import OpenColor from 'open-color';
+// https://yeun.github.io/open-color/
+
+const colors = {
+  default: {
+    background: OpenColor.white,
+    color: OpenColor.gray[9],
+  },
+  green: {
+    background: OpenColor.green[7],
+    color: OpenColor.white,
+  },
+  gray: {
+    background: OpenColor.gray[6],
+    color: OpenColor.white,
+  },
+  whiteRed: {
+    background: OpenColor.white,
+    color: OpenColor.red[8],
+  },
+};
+
+export default colors;

--- a/front/src/components/CustomButton.js
+++ b/front/src/components/CustomButton.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import theme from './ColorStyle';
+
+const Button = styled.button`
+  width: fit-content;
+  border: 0.1rem solid;
+  border-radius: 0.4rem;
+  padding: 0.5rem;
+  ${(props) => props.style};
+`;
+
+function CustomButton({ handleClick, children, style = {} }) {
+  const colorStyle = theme[style.color] || theme.default;
+  const fontSize = style.size === 'sm' ? '0.8rem' : '1rem';
+  return (
+    <Button style={{ fontSize, ...colorStyle }} onClick={handleClick}>
+      {children}
+    </Button>
+  );
+}
+
+CustomButton.propTypes = {
+  handleClick: PropTypes.func.isRequired,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
+  style: PropTypes.objectOf(PropTypes.object).isRequired,
+};
+export default CustomButton;


### PR DESCRIPTION
- ColorStyle 추가
기본적으로 open-color의 색상을 사용하여 필요한 버튼 색상테마별로 색상을 지정해두었습니다.
borderColor의 경우에는 버튼색상이 있는 경우에는 `transparent` 속성을 주었습니다.

- CustomButton 추가
참고 코드가 동작하도록 수정하여 통합커스텀버튼 추가했습니다.
기본 버튼에 테두리도 있어서 styled-components에 테투리 속성을 추가했습니다.

**확인을 위해 임시로 App.js에 CustomButton 컴포넌트를 추가했을 시 잘 만들어지는 것을 확인**
![image](https://user-images.githubusercontent.com/46044132/97467748-d9c86380-1987-11eb-9353-79be6c6d9144.png)
```javascript
 return (
    <Router>
      <Route exact path="/">
        <div>
          <div>{title}</div>
          <button onClick={sss1}> button</button>
          <CustomButton style={{color:"green"}}>green</CustomButton>
          <CustomButton style={{color:"gray"}}>gray</CustomButton>
          <CustomButton style={{color:"whiteRed"}}>background is White and font-color is red</CustomButton>
          <CustomButton>default</CustomButton>
          <MovePageButton className="label-button" name="label" />
        </div>
      </Route>
      <Route exact path="/test">
        <MovePageButton className="test" name="test" />
      </Route>
    </Router>
  );
};
```

❓❓❓
흰색 바탕에 빨간 글씨에 대한 이름을 whiteRed라고 일단 선언해두었는데 더 좋은 이름이 있을까요?


