### PR TITLE
Feat: github action으로 자동 리뷰어 생성

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,11 @@
+addReviewers: true
+
+addAssignees: writer
+
+reviewers:
+  - changheedev
+  - rolled-potatoes
+  - LeeSuKyeong
+  - yejineee
+
+numberOfReviewers: 0

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,6 +1,6 @@
 addReviewers: true
 
-addAssignees: writer
+addAssignees: author
 
 reviewers:
   - changheedev

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,8 @@
+name: 'Auto Assign'
+on: pull_request
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.1.2


### PR DESCRIPTION
### 구현 사항
- PR에 Reviewers를 PR 작성자를 제외한 25조 팀원들을 자동으로 지정
- PR에 Assignee를 작성자로 지정


To. 이 PR을 보는 모든 분들께
앞으로 PR 보내실때 Reviewer와 Assignee는 지정하지 않으셔도,
자동으로 지정이 됩니다!