### PR TITLE
Refactor: 리뷰어 자동 등록 스크립트 수정

### DIFF
--- a/.github/workflows/auto-reviewer.yml
+++ b/.github/workflows/auto-reviewer.yml
@@ -6,3 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: kentaro-m/auto-assign-action@v1.1.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          


### PR DESCRIPTION
해당 스크립트를 사용할 때 GITHUB_TOKEN을 등록해주어야 하는 것 같아서 추가했습니다.