### PR TITLE
Feat: Login 화면 컴포넌트 구현 및 프론트 API_BASE_URL 환경 변수 추가

### DIFF
--- a/front/src/apis/axios.js
+++ b/front/src/apis/axios.js
@@ -1,9 +1,7 @@
 import axios from 'axios';
 
-const isProd = process.env.NODE_ENV === 'production';
-
 const instance = axios.create({
-  baseURL: isProd ? '/api' : 'http://localhost:3000',
+  baseURL: process.env.API_BASE_URL,
 });
 
 instance.interceptors.response.use(

--- a/front/src/routes/Login/LoginPage.js
+++ b/front/src/routes/Login/LoginPage.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import styled from 'styled-components';
+import color from '../../libs/color';
+
+const GithubButton = styled.button`
+  display: flex;
+  width: fit-content;
+  height: 2rem;
+  justify-content: center;
+  align-items: center;
+  background: ${color.darkGray};
+  color: ${color.white};
+
+  &:hover {
+    background: ${color.gray};
+  }
+`;
+const LoginButtonContainer = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+const LoginTitle = styled.div`
+  font-weight: bolder;
+  font-size: x-large;
+`;
+const Div = styled.div`
+  display: flex;
+  margin: 0 auto;
+  margin-top: 20vh;
+
+  width: 30vw;
+  height: 30vh;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+
+  box-shadow: 0px 1px 10px 0px ${color.gray};
+`;
+function LoginPage() {
+  const loginUrl = `${process.env.API_BASE_URL}/oauth/github`;
+  return (
+    <Div>
+      <LoginTitle>이슈트랙커</LoginTitle>
+      <LoginButtonContainer>
+        <a href={loginUrl}>
+          <GithubButton type="button">Sign in with Github</GithubButton>
+        </a>
+      </LoginButtonContainer>
+    </Div>
+  );
+}
+
+export default LoginPage;

--- a/front/webpack.config.js
+++ b/front/webpack.config.js
@@ -51,6 +51,11 @@ module.exports = {
           : false,
     }),
     new webpack.DefinePlugin({
+      'process.env.API_BASE_URL': JSON.stringify(
+        process.env.NODE_ENV === 'production'
+          ? '/api'
+          : 'http://localhost:3000',
+      ),
       'process.env.NODE_ENV': JSON.stringify(
         process.env.NODE_ENV || 'development',
       ),


### PR DESCRIPTION
## 구현 사항
- 로그인 화면 컴포넌트를 추가하였습니다.
- API_BASE_URL을 node_env에 따라 다른 url을 주는 것으로 설정하고, 환경 변수로 등록하였습니다.

## 참고
- App.js에서 routes/Login/LoginPage에서 import 받으시면 됩니다.

## 로그인 화면
- 첫 화면
<img width="928" alt="스크린샷 2020-11-03 오후 5 59 17" src="https://user-images.githubusercontent.com/43772082/97965816-4c10cc00-1dfe-11eb-8a30-62d311a80c97.png">

- 버튼 클릭 시 깃헙 로그인 페이지로 넘어가게 됩니다.