### PR TITLE
Refactor: 이슈 리스트 가져오는 것 api에 맞게 수정 & css 작업

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "axios": "^0.21.0",
+    "moment": "^2.29.1",
     "open-color": "^1.7.0",
     "prop-types": "^15.7.2",
     "query-string": "^6.13.6",

--- a/front/src/components/Label.js
+++ b/front/src/components/Label.js
@@ -11,10 +11,10 @@ const LabelItem = styled.div`
   color: white;
   mix-blend-mode: difference;
 `;
-function Label({ label }) {
+function Label({ label, children }) {
   return (
     <LabelItem className="Label" color={label.color}>
-      {label.name}
+      {children}
     </LabelItem>
   );
 }

--- a/front/src/components/Label.js
+++ b/front/src/components/Label.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const LabelItem = styled.div`
+  display: inline-block;
+  margin: 0 0.5rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 1rem;
+
+  background: ${({ color }) => color};
+  color: white;
+  mix-blend-mode: difference;
+`;
+function Label({ label }) {
+  return (
+    <LabelItem className="Label" color={label.color}>
+      {label.name}
+    </LabelItem>
+  );
+}
+
+export default Label;

--- a/front/src/components/UserProfile.js
+++ b/front/src/components/UserProfile.js
@@ -16,7 +16,7 @@ export const UserProfileList = ({ users }) => {
         <UserProfile
           key={user.id}
           id={user.id}
-          src={user.profile_link}
+          src={user.profileLink}
           size="sm"
         />
       ))}

--- a/front/src/libs/utils.js
+++ b/front/src/libs/utils.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 export default {
   countFilteredElement(list, condition) {
     const filteredList = list.filter((element) => condition(element));
@@ -5,5 +7,8 @@ export default {
   },
   getFilteredElement(list, condition) {
     return list.filter((element) => condition(element));
+  },
+  timeDiffFromNow(date) {
+    return moment(date).fromNow();
   },
 };

--- a/front/src/routes/IssueList/IssueListContainer.js
+++ b/front/src/routes/IssueList/IssueListContainer.js
@@ -2,9 +2,12 @@ import React from 'react';
 import styled from 'styled-components';
 import color from '../../libs/color';
 import actionType from './action-type';
+import utils from '../../libs/utils';
 import ListHeader from '../../components/ListHeader';
 import { UserProfileList } from '../../components/UserProfile';
+import LabelItem from '../../components/Label';
 
+const { timeDiffFromNow } = utils;
 const { CHECK_ALL_ISSUE_HANDLER, CHECK_ISSUE_HANDLER } = actionType;
 const CustomCheckBoxButton = styled.button`
   width: 1rem;
@@ -16,8 +19,17 @@ const IssueList = styled.div`
   color: ${color.black};
 `;
 const IssueItemContainer = styled.li`
+  display: flex;
   border-top: 1px solid ${color.lightGray};
   padding: 1rem;
+  justify-content: space-between;
+
+  & .issue-item__title {
+    font-weight: bold;
+  }
+  & .issue-item__info-msg {
+    color: ${color.Gray};
+  }
 `;
 
 const Ul = styled.ul`
@@ -26,6 +38,12 @@ const Ul = styled.ul`
   list-style-type: none;
 `;
 
+const UserProfileContainer = styled.div`
+  display: flex;
+  width: 40%;
+  justify-content: center;
+  align-items: center;
+`;
 function IssueListHeader({ checkAllIssue, dispatch }) {
   const checkBoxClickHandler = () => {
     dispatch({ type: CHECK_ALL_ISSUE_HANDLER });
@@ -41,20 +59,40 @@ function IssueListHeader({ checkAllIssue, dispatch }) {
   );
 }
 
+function LabelContainer({ labels }) {
+  return (
+    <>
+      {labels.map((label) => (
+        <LabelItem key={label.id} id={label.id} label={label} />
+      ))}
+    </>
+  );
+}
+
 function IssueItem({ issue, checkBoxClickHandler }) {
   const {
     id,
     title,
-    writer,
-    milestoneTitle,
     checked,
     isClosed,
-    assigneeList,
+    createdAt,
+    closedAt,
+    Author: author,
+    Milestone: milestone,
+    Assignees: assignees,
+    Labels: labels,
   } = issue;
 
+  const openedInfoMsg = `#${id} opened ${timeDiffFromNow(createdAt)} by ${
+    author.name
+  }`;
+  const closedInfoMsg = `#${id} by ${author.name} was closed ${timeDiffFromNow(
+    closedAt,
+  )}`;
+  const issueInfoMsg = isClosed ? closedInfoMsg : openedInfoMsg;
   return (
     <IssueItemContainer id={id}>
-      <div>
+      <div className="issue-item__left-container">
         <CustomCheckBoxButton
           type="button"
           checked={checked}
@@ -62,22 +100,19 @@ function IssueItem({ issue, checkBoxClickHandler }) {
           id={id}
         />
         <span className="issue-item__title">{title}</span>
-        <span className="issue-item__label">라벨</span>
+        {labels && <LabelContainer labels={labels} />}
+        <div>
+          <span className="issue-item__info-msg">{issueInfoMsg}</span>
+          {milestone && (
+            <span className="issue-item__milestone-title" id={milestone.id}>
+              {milestone.title}
+            </span>
+          )}
+        </div>
       </div>
-      <div>
-        <span className="issue-item__issue-number">#{id}</span>
-        <span className="issue-item__date">
-          {isClosed ? 'closed' : 'opened'}
-        </span>
-        <span className="issue-item__writer">{writer}</span>
-        {milestoneTitle !== '' && (
-          <span className="issue-item__milestone-title">{milestoneTitle}</span>
-        )}
-        <UserProfileList
-          className="issue-item__assignee"
-          users={assigneeList}
-        />
-      </div>
+      <UserProfileContainer>
+        <UserProfileList className="issue-item__assignee" users={assignees} />
+      </UserProfileContainer>
     </IssueItemContainer>
   );
 }

--- a/front/src/routes/IssueList/IssueListContainer.js
+++ b/front/src/routes/IssueList/IssueListContainer.js
@@ -63,7 +63,9 @@ function LabelContainer({ labels }) {
   return (
     <>
       {labels.map((label) => (
-        <LabelItem key={label.id} id={label.id} label={label} />
+        <LabelItem key={label.id} id={label.id} label={label}>
+          {label.name}
+        </LabelItem>
       ))}
     </>
   );

--- a/front/src/routes/IssueList/IssueListContainer.js
+++ b/front/src/routes/IssueList/IssueListContainer.js
@@ -24,10 +24,13 @@ const IssueItemContainer = styled.li`
   padding: 1rem;
   justify-content: space-between;
 
-  & .issue-item__title {
+  .issue-item + .issue-item {
+    margin-left: 1rem;
+  }
+  .issue-item__title {
     font-weight: bold;
   }
-  & .issue-item__info-msg {
+  .issue-item__info-msg {
     color: ${color.Gray};
   }
 `;
@@ -101,19 +104,27 @@ function IssueItem({ issue, checkBoxClickHandler }) {
           onClick={checkBoxClickHandler}
           id={id}
         />
-        <span className="issue-item__title">{title}</span>
+        <span className="issue-item issue-item__title">{title}</span>
         {labels && <LabelContainer labels={labels} />}
         <div>
-          <span className="issue-item__info-msg">{issueInfoMsg}</span>
+          <span className="issue-item issue-item__info-msg">
+            {issueInfoMsg}
+          </span>
           {milestone && (
-            <span className="issue-item__milestone-title" id={milestone.id}>
+            <span
+              className="issue-item issue-item__milestone-title"
+              id={milestone.id}
+            >
               {milestone.title}
             </span>
           )}
         </div>
       </div>
       <UserProfileContainer>
-        <UserProfileList className="issue-item__assignee" users={assignees} />
+        <UserProfileList
+          className="issue-item issue-item__assignee"
+          users={assignees}
+        />
       </UserProfileContainer>
     </IssueItemContainer>
   );

--- a/front/src/routes/IssueList/IssueListPage.js
+++ b/front/src/routes/IssueList/IssueListPage.js
@@ -15,7 +15,8 @@ const Div = styled.div`
 function IssueListPage() {
   const [state, dispatch] = useReducer(reducer, {
     issues: undefined,
-    filteredIssues: undefined,
+    page: undefined,
+    lastPage: undefined,
     checkAllIssue: false,
     error: undefined,
     loading: true,
@@ -23,8 +24,11 @@ function IssueListPage() {
 
   const fetchIssue = async () => {
     try {
-      const issues = await issueApi.getIssues();
-      dispatch({ type: FETCH_SUCCESS, issueItems: issues });
+      const {
+        pagination: { page, lastPage },
+        issues,
+      } = await issueApi.getIssues();
+      dispatch({ type: FETCH_SUCCESS, issues, page, lastPage });
     } catch (e) {
       dispatch({ type: FETCH_ERROR, error: e.message });
     }
@@ -34,21 +38,21 @@ function IssueListPage() {
     fetchIssue();
   }, []);
 
-  const { filteredIssues, checkAllIssue, error, loading } = state;
+  const { issues, checkAllIssue, error, loading } = state;
   if (error) {
     return <div>{error}</div>;
   }
   if (loading) {
     return null;
   }
-  if (filteredIssues.length === 0) {
+  if (issues.length === 0) {
     return <div>No results matched your search.</div>;
   }
   return (
     <Div>
       <IssueFilterContainer />
       <IssueListContainer
-        issues={filteredIssues}
+        issues={issues}
         checkAllIssue={checkAllIssue}
         dispatch={dispatch}
       />

--- a/front/src/routes/IssueList/reducer.js
+++ b/front/src/routes/IssueList/reducer.js
@@ -1,5 +1,4 @@
 import actionType from './action-type';
-import utils from '../../libs/utils';
 
 const {
   FETCH_SUCCESS,
@@ -10,22 +9,16 @@ const {
 
 export default function reducer(state, action) {
   const { type } = action;
-  const { filteredIssues, checkAllIssue } = state;
+  const { issues, checkAllIssue } = state;
   switch (type) {
     case FETCH_SUCCESS: {
-      const { issueItems } = action;
-      const openedIssues = utils.getFilteredElement(
-        issueItems,
-        (issue) => !issue.isClosed,
-      );
+      const { issues: filteredIssues, page, lastPage } = action;
       return {
         ...state,
         loading: false,
-        issues: [...issueItems],
-        filteredIssues: openedIssues.map((issue) => ({
-          ...issue,
-          checked: false,
-        })),
+        issues: setAllIssueChecked(filteredIssues, false),
+        page,
+        lastPage,
       };
     }
     case FETCH_ERROR: {
@@ -36,26 +29,22 @@ export default function reducer(state, action) {
       };
     }
     case CHECK_ALL_ISSUE_HANDLER: {
-      const updatedAllIssues = setAllIssueChecked(
-        filteredIssues,
-        !checkAllIssue,
-      );
+      const updatedAllIssues = setAllIssueChecked(issues, !checkAllIssue);
       return {
         ...state,
-        filteredIssues: updatedAllIssues,
+        issues: updatedAllIssues,
         checkAllIssue: !checkAllIssue,
       };
     }
     case CHECK_ISSUE_HANDLER: {
       const { id } = action;
-      const updatedOneIssue = toggleIssue(filteredIssues, id);
+      const updatedOneIssue = toggleIssue(issues, id);
       return {
         ...state,
-        filteredIssues: updatedOneIssue,
+        issues: updatedOneIssue,
         checkAllIssue: isAllChecked(updatedOneIssue),
       };
     }
-
     default:
       return state;
   }


### PR DESCRIPTION
close #92 
## 구현 내용
- 이슈 리스트 가져오는 api에 맞게 데이터 가져와서 렌더링해주도록 하였습니다.
- 오픈된 날짜, 닫힌 날짜를 현재 시간으로부터 몇시간 전인지를 보여주는데, moment 라이브러리를 사용하였습니다.
- 이슈 리스트 페이지 css를 추가하였습니다.

## 리뷰 반영
- Labels 컴포넌트 생성하였습니다. color 를 props로 전달해주면 백그라운드 컬러를 color로 하는 라벨 컴포넌트를 만들어줍니다.
- 이슈 안의 내용 사이에 간격을 띄웠습니다.
![스크린샷 2020-11-05 오후 1 31 41](https://user-images.githubusercontent.com/43772082/98197973-44226a80-1f6b-11eb-8b84-a0a1dd6118b3.png)


## 부족한 점 
- 라벨의 백그라운드를 가져왔을 때, 백그라운드 컬러에 따라 폰트 컬러가 달라지게 했으면 좋을 것 같습니다.
