### PR TITLE
Issue seeder 코드 수정

### DIFF
--- a/server/src/libs/seeders/issue.js
+++ b/server/src/libs/seeders/issue.js
@@ -33,7 +33,7 @@ export async function up() {
     .reduce((issues, cur, idx) => {
       const authorId = utils.getValidData(userIds, idx);
       const milestoneId = utils.getValidData(milestoneIds, idx);
-      const closedStatus = idx % 2 === 0;
+      const closedStatus = Math.floor(Math.random() * 2) === 0;
 
       const issue = {
         title: `${baseTitle} ${idx}`,


### PR DESCRIPTION
이슈 데이터를 생성할 때 milestoneId와 isClosed를 idx 기준으로 생성하면서 같은 milestoneId에 속하는 모든 issue의 isClosed가 같은
현상이 있습니다. 그래서 open/close 상태가 적절히 섞이도록 수정해주었습니다.