### PR TITLE
Feat: 새로운 이슈 등록 API

### DIFF
--- a/server/src/libs/passport.js
+++ b/server/src/libs/passport.js
@@ -19,7 +19,7 @@ const GitHubVerifyCallback = async (
       defaults: {
         uid: profile.id,
         name: profile.username,
-        profileLink: profile.profileUrl,
+        profileLink: profile.photos[0].value,
       },
     });
     return done(null, user);

--- a/server/src/libs/seeders/milestone.js
+++ b/server/src/libs/seeders/milestone.js
@@ -5,7 +5,7 @@ const { Milestone: MilestoneModel } = db.sequelize.models;
 export async function up() {
   const baseTitle = 'week ';
   const baseDescription = '마일스톤 설명 ';
-  const endDates = ['2020-10-31', null, '2020-12-24'];
+  const endDates = ['2020-11-22', null, '2021-05-24'];
   const bulkMilestone = endDates.reduce((milestones, endDate, idx) => {
     const milestone = {
       title: `${baseTitle}${idx + 1}`,

--- a/server/src/routes/issue/controller.js
+++ b/server/src/routes/issue/controller.js
@@ -18,6 +18,19 @@ const IssueController = (issueService) => ({
       return next(err);
     }
   },
+  async registerIssue(req, res, next) {
+    try {
+      const userId = req.user.id;
+      const registerPayload = req.body;
+      const newIssueId = await issueService.registerIssue(
+        registerPayload,
+        userId,
+      );
+      return res.status(200).json({ id: newIssueId });
+    } catch (err) {
+      return next(err);
+    }
+  },
 });
 
 export default IssueController;

--- a/server/src/routes/issue/index.js
+++ b/server/src/routes/issue/index.js
@@ -3,6 +3,8 @@ import IssueController from './controller';
 import IssueService from '../../services/issue';
 import db from '../../models';
 
+const { Sequelize } = db;
+
 const {
   Issue: IssueModel,
   User: UserModel,
@@ -19,10 +21,12 @@ const issueController = IssueController(
     LabelModel,
     MilestoneModel,
     CommentModel,
+    Sequelize,
   }),
 );
 
 router.get('/', issueController.getIssueList);
 router.get('/:id', issueController.getIssue);
+router.post('/', issueController.registerIssue);
 
 export default router;


### PR DESCRIPTION
## 구현 사항
- 새로운 이슈 등록 API
- milestone seeder의 endDate 수정
milestone의 endDate는 createdAt보다 이후여야 하므로,
createdAt 이후로 수정한다.