### PR TITLE
이슈 등록 API 트랜잭션 처리 추가

### DIFF
--- a/server/src/routes/issue/index.js
+++ b/server/src/routes/issue/index.js
@@ -3,7 +3,7 @@ import IssueController from './controller';
 import IssueService from '../../services/issue';
 import db from '../../models';
 
-const { Sequelize } = db;
+const { Sequelize, sequelize } = db;
 
 const {
   Issue: IssueModel,
@@ -11,7 +11,7 @@ const {
   Label: LabelModel,
   Milestone: MilestoneModel,
   Comment: CommentModel,
-} = db.sequelize.models;
+} = sequelize.models;
 
 const router = express.Router();
 const issueController = IssueController(
@@ -22,6 +22,7 @@ const issueController = IssueController(
     MilestoneModel,
     CommentModel,
     Sequelize,
+    sequelize,
   }),
 );
 

--- a/server/src/services/issue/index.js
+++ b/server/src/services/issue/index.js
@@ -144,10 +144,10 @@ const IssueService = ({
         getAssociatedAssignees(payload.assignees),
       ]);
       if (labels) {
-        issue.addLabels(labels, { transaction });
+        await issue.addLabels(labels, { transaction });
       }
       if (assignees) {
-        issue.addAssignees(assignees, { transaction });
+        await issue.addAssignees(assignees, { transaction });
       }
       await transaction.commit();
       return issue.id;

--- a/server/src/services/issue/index.js
+++ b/server/src/services/issue/index.js
@@ -5,6 +5,7 @@ const IssueService = ({
   MilestoneModel,
   CommentModel,
   Sequelize,
+  sequelize,
 }) => {
   const { Op } = Sequelize;
 
@@ -135,18 +136,25 @@ const IssueService = ({
       milestoneId,
       authorId: loggedUserId,
     };
-    const issue = await IssueModel.create(newIssue);
-    const [labels, assignees] = await Promise.all([
-      getAssociatedLabels(payload.labels),
-      getAssociatedAssignees(payload.assignees),
-    ]);
-    if (labels) {
-      issue.addLabels(labels);
+    const transaction = await sequelize.transaction();
+    try {
+      const issue = await IssueModel.create(newIssue, { transaction });
+      const [labels, assignees] = await Promise.all([
+        getAssociatedLabels(payload.labels),
+        getAssociatedAssignees(payload.assignees),
+      ]);
+      if (labels) {
+        issue.addLabels(labels, { transaction });
+      }
+      if (assignees) {
+        issue.addAssignees(assignees, { transaction });
+      }
+      await transaction.commit();
+      return issue.id;
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
     }
-    if (assignees) {
-      issue.addAssignees(assignees);
-    }
-    return issue.id;
   };
 
   return {


### PR DESCRIPTION
이슈 등록 API에서 Insert 작업이 여러 단계로 일어나기 때문에 중간에 오류가 발생했을때 롤백이 되도록 트랜잭션 처리를 추가해주었습니다.