### PR TITLE
이슈 수정 API 구현

### DIFF
--- a/front/src/components/issue/detail/body/index.js
+++ b/front/src/components/issue/detail/body/index.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import Comment from './Comment';
 import SidebarLayout from '../../../commons/SidebarLayout';
+import Sidebar from '../../../../models/sidebar';
 
-const IssueDetailBody = ({ issue }) => {
+const IssueDetailBody = ({ issue, handlers, seletedState }) => {
   return (
     <SidebarLayout.BaseLayout>
       <SidebarLayout.Content>
@@ -25,7 +26,9 @@ const IssueDetailBody = ({ issue }) => {
           })}
         </>
       </SidebarLayout.Content>
-      <SidebarLayout.Sidebar>sidebar</SidebarLayout.Sidebar>
+      <SidebarLayout.Sidebar>
+        <Sidebar selected={seletedState} handlers={handlers} />
+      </SidebarLayout.Sidebar>
     </SidebarLayout.BaseLayout>
   );
 };

--- a/front/src/models/issue/detail/index.js
+++ b/front/src/models/issue/detail/index.js
@@ -8,6 +8,7 @@ import {
 import issueAPI from '../../../apis/issue';
 import utils from '../../../libs/utils';
 import { useAsync } from '../../../hooks/useAsync';
+import useSidebar from '../../../hooks/useSidebar';
 import reducer from './reducer';
 
 const initialState = {
@@ -18,6 +19,7 @@ const initialState = {
 const IssueDetailPage = () => {
   const { id } = useParams();
   const getIssueApi = () => issueAPI.getIssue(id);
+  const { state: seletedState, handlers } = useSidebar();
   const { state, fetchStatus } = useAsync({
     api: getIssueApi,
     reducer,
@@ -38,7 +40,11 @@ const IssueDetailPage = () => {
     !utils.isEmpty(issue) && (
       <>
         <IssueDetailHeader issue={issue} />
-        <IssueDetailBody issue={issue} />
+        <IssueDetailBody
+          issue={issue}
+          seletedState={seletedState}
+          handlers={handlers}
+        />
       </>
     )
   );

--- a/server/src/routes/issue/controller.js
+++ b/server/src/routes/issue/controller.js
@@ -31,6 +31,20 @@ const IssueController = (issueService) => ({
       return next(err);
     }
   },
+  async updateTitle(req, res, next) {
+    try {
+      const userId = req.user.id;
+      const issueId = req.params.id;
+      const updateTitlePayload = req.body;
+      await issueService.updateTitle(
+        { id: issueId, ...updateTitlePayload },
+        userId,
+      );
+      return res.end();
+    } catch (err) {
+      return next(err);
+    }
+  },
 });
 
 export default IssueController;

--- a/server/src/routes/issue/controller.js
+++ b/server/src/routes/issue/controller.js
@@ -45,6 +45,20 @@ const IssueController = (issueService) => ({
       return next(err);
     }
   },
+  async updateContents(req, res, next) {
+    try {
+      const userId = req.user.id;
+      const issueId = req.params.id;
+      const updateContentsPayload = req.body;
+      await issueService.updateContents(
+        { id: issueId, ...updateContentsPayload },
+        userId,
+      );
+      return res.end();
+    } catch (err) {
+      return next(err);
+    }
+  },
 });
 
 export default IssueController;

--- a/server/src/routes/issue/controller.js
+++ b/server/src/routes/issue/controller.js
@@ -10,7 +10,7 @@ const IssueController = (issueService) => ({
   },
   async getIssue(req, res, next) {
     try {
-      const issueId = req.params.id;
+      const { id: issueId } = req.params;
       const userId = req.user.id;
       const issue = await issueService.getIssue(issueId, userId);
       return res.status(200).json(issue);
@@ -31,23 +31,13 @@ const IssueController = (issueService) => ({
       return next(err);
     }
   },
-  async updateMilestone(req, res, next) {
-    const { id: issueId } = req.params;
-    const { milestoneId } = req.body;
-    try {
-      await issueService.updateMilestone(issueId, milestoneId);
-      return res.end();
-    } catch (err) {
-      return next(err);
-    }
-  },
   async updateTitle(req, res, next) {
     try {
+      const { id: issueId } = req.params;
       const userId = req.user.id;
-      const issueId = req.params.id;
       const updateTitlePayload = req.body;
       await issueService.updateTitle(
-        { id: issueId, ...updateTitlePayload },
+        { issueId, ...updateTitlePayload },
         userId,
       );
       return res.end();
@@ -55,11 +45,24 @@ const IssueController = (issueService) => ({
       return next(err);
     }
   },
+  async updateMilestone(req, res, next) {
+    const { id: issueId } = req.params;
+    const updateMilestonePayload = req.body;
+    try {
+      await issueService.updateMilestone({
+        issueId,
+        ...updateMilestonePayload,
+      });
+      return res.end();
+    } catch (err) {
+      return next(err);
+    }
+  },
   async updateLabels(req, res, next) {
     const { id: issueId } = req.params;
-    const { labels } = req.body;
+    const updateLabelsPayload = req.body;
     try {
-      await issueService.updateLabels(issueId, labels);
+      await issueService.updateLabels({ issueId, ...updateLabelsPayload });
       return res.end();
     } catch (err) {
       return next(err);
@@ -68,10 +71,10 @@ const IssueController = (issueService) => ({
   async updateContents(req, res, next) {
     try {
       const userId = req.user.id;
-      const issueId = req.params.id;
+      const { id: issueId } = req.params;
       const updateContentsPayload = req.body;
       await issueService.updateContents(
-        { id: issueId, ...updateContentsPayload },
+        { issueId, ...updateContentsPayload },
         userId,
       );
       return res.end();
@@ -81,10 +84,10 @@ const IssueController = (issueService) => ({
   },
   async updateAssignees(req, res, next) {
     try {
-      const issueId = req.params.id;
+      const { id: issueId } = req.params;
       const updateAssigneesPayload = req.body;
       await issueService.updateAssignees({
-        id: issueId,
+        issueId,
         ...updateAssigneesPayload,
       });
       return res.end();

--- a/server/src/routes/issue/controller.js
+++ b/server/src/routes/issue/controller.js
@@ -59,6 +59,19 @@ const IssueController = (issueService) => ({
       return next(err);
     }
   },
+  async updateAssignees(req, res, next) {
+    try {
+      const issueId = req.params.id;
+      const updateAssigneesPayload = req.body;
+      await issueService.updateAssignees({
+        id: issueId,
+        ...updateAssigneesPayload,
+      });
+      return res.end();
+    } catch (err) {
+      return next(err);
+    }
+  },
 });
 
 export default IssueController;

--- a/server/src/routes/issue/controller.js
+++ b/server/src/routes/issue/controller.js
@@ -31,6 +31,16 @@ const IssueController = (issueService) => ({
       return next(err);
     }
   },
+  async updateMilestone(req, res, next) {
+    const { id: issueId } = req.params;
+    const { milestoneId } = req.body;
+    try {
+      await issueService.updateMilestone(issueId, milestoneId);
+      return res.end();
+    } catch (err) {
+      return next(err);
+    }
+  },
   async updateTitle(req, res, next) {
     try {
       const userId = req.user.id;
@@ -40,6 +50,16 @@ const IssueController = (issueService) => ({
         { id: issueId, ...updateTitlePayload },
         userId,
       );
+      return res.end();
+    } catch (err) {
+      return next(err);
+    }
+  },
+  async updateLabels(req, res, next) {
+    const { id: issueId } = req.params;
+    const { labels } = req.body;
+    try {
+      await issueService.updateLabels(issueId, labels);
       return res.end();
     } catch (err) {
       return next(err);

--- a/server/src/routes/issue/index.js
+++ b/server/src/routes/issue/index.js
@@ -29,4 +29,5 @@ router.get('/', issueController.getIssueList);
 router.get('/:id', issueController.getIssue);
 router.post('/', issueController.registerIssue);
 router.put('/:id/title', issueController.updateTitle);
+router.put('/:id/contents', issueController.updateContents);
 export default router;

--- a/server/src/routes/issue/index.js
+++ b/server/src/routes/issue/index.js
@@ -3,7 +3,7 @@ import IssueController from './controller';
 import IssueService from '../../services/issue';
 import db from '../../models';
 
-const { Sequelize } = db;
+const { Sequelize, sequelize } = db;
 
 const {
   Issue: IssueModel,
@@ -22,6 +22,7 @@ const issueController = IssueController(
     MilestoneModel,
     CommentModel,
     Sequelize,
+    sequelize,
   }),
 );
 

--- a/server/src/routes/issue/index.js
+++ b/server/src/routes/issue/index.js
@@ -28,5 +28,5 @@ const issueController = IssueController(
 router.get('/', issueController.getIssueList);
 router.get('/:id', issueController.getIssue);
 router.post('/', issueController.registerIssue);
-
+router.put('/:id/title', issueController.updateTitle);
 export default router;

--- a/server/src/routes/issue/index.js
+++ b/server/src/routes/issue/index.js
@@ -28,6 +28,8 @@ const issueController = IssueController(
 router.get('/', issueController.getIssueList);
 router.get('/:id', issueController.getIssue);
 router.post('/', issueController.registerIssue);
+router.put('/:id/milestones', issueController.updateMilestone);
+router.put('/:id/labels', issueController.updateLabels);
 router.put('/:id/title', issueController.updateTitle);
 router.put('/:id/contents', issueController.updateContents);
 router.put('/:id/assignees', issueController.updateAssignees);

--- a/server/src/routes/issue/index.js
+++ b/server/src/routes/issue/index.js
@@ -30,4 +30,5 @@ router.get('/:id', issueController.getIssue);
 router.post('/', issueController.registerIssue);
 router.put('/:id/title', issueController.updateTitle);
 router.put('/:id/contents', issueController.updateContents);
+router.put('/:id/assignees', issueController.updateAssignees);
 export default router;

--- a/server/src/services/issue/index.js
+++ b/server/src/services/issue/index.js
@@ -7,6 +7,10 @@ const IssueService = ({
   Sequelize,
 }) => {
   const { Op } = Sequelize;
+  const messages = {
+    NOT_FOUND: '등록되지 않은 이슈 id 입니다.',
+    ACCESS_DENIED: '접근 권한이 없습니다.',
+  };
 
   const getTotalIssueCount = async () => {
     const totalIssueCount = await IssueModel.count();
@@ -149,10 +153,32 @@ const IssueService = ({
     return issue.id;
   };
 
+  const checkIsAuthor = (issue, loggedUserId) => {
+    if (issue.authorId === loggedUserId) {
+      return true;
+    }
+    return false;
+  };
+
+  const updateTitle = async (payload, loggedUserId) => {
+    const { id, title } = payload;
+
+    const issue = await IssueModel.findByPk(id);
+    if (!issue) {
+      throw new Error(messages.NOT_FOUND);
+    }
+    if (!checkIsAuthor(issue, loggedUserId)) {
+      throw new Error(messages.ACCESS_DENIED);
+    }
+    issue.title = title;
+    await issue.save();
+  };
+
   return {
     getIssueList,
     getIssue,
     registerIssue,
+    updateTitle,
   };
 };
 

--- a/server/src/services/issue/index.js
+++ b/server/src/services/issue/index.js
@@ -160,17 +160,30 @@ const IssueService = ({
     return false;
   };
 
-  const updateTitle = async (payload, loggedUserId) => {
-    const { id, title } = payload;
-
-    const issue = await IssueModel.findByPk(id);
+  const getValidIssue = async (issueId, loggedUserId) => {
+    const issue = await IssueModel.findByPk(issueId);
     if (!issue) {
       throw new Error(messages.NOT_FOUND);
     }
     if (!checkIsAuthor(issue, loggedUserId)) {
       throw new Error(messages.ACCESS_DENIED);
     }
+    return issue;
+  };
+
+  const updateTitle = async (payload, loggedUserId) => {
+    const { id, title } = payload;
+
+    const issue = await getValidIssue(id, loggedUserId);
     issue.title = title;
+    await issue.save();
+  };
+
+  const updateContents = async (payload, loggedUserId) => {
+    const { id, contents } = payload;
+
+    const issue = await getValidIssue(id, loggedUserId);
+    issue.contents = contents;
     await issue.save();
   };
 
@@ -179,6 +192,7 @@ const IssueService = ({
     getIssue,
     registerIssue,
     updateTitle,
+    updateContents,
   };
 };
 

--- a/server/src/services/issue/index.js
+++ b/server/src/services/issue/index.js
@@ -187,12 +187,32 @@ const IssueService = ({
     await issue.save();
   };
 
+  const updateAssignees = async (payload) => {
+    const { id, assignees: newAssignees } = payload;
+    const issue = await IssueModel.findByPk(id, {
+      include: {
+        model: UserModel,
+        as: 'Assignees',
+        through: { attributes: [] },
+      },
+    });
+    if (!issue) {
+      throw new Error(messages.NOT_FOUND);
+    }
+    const assignees = await getAssociatedAssignees(newAssignees);
+    if (assignees) {
+      await issue.removeAssignees(issue.Assignees);
+      await issue.addAssignees(assignees);
+    }
+  };
+
   return {
     getIssueList,
     getIssue,
     registerIssue,
     updateTitle,
     updateContents,
+    updateAssignees,
   };
 };
 

--- a/server/src/services/issue/index.js
+++ b/server/src/services/issue/index.js
@@ -152,6 +152,26 @@ const IssueService = ({
     }
     return issue.id;
   };
+  const updateMilestone = async (issueId, milestoneId) => {
+    const issue = await IssueModel.findByPk(issueId);
+    const id = issue.milestoneId === milestoneId ? null : milestoneId;
+    issue.milestoneId = id;
+    await issue.save();
+  };
+  const updateLabels = async (issueId, labels) => {
+    const issue = await IssueModel.findByPk(issueId, {
+      include: {
+        model: LabelModel,
+        through: { attributes: [] },
+      },
+    });
+    await issue.removeLabels(issue.Labels);
+    const associatedLabels = await getAssociatedLabels(labels);
+    if (associatedLabels) {
+      await issue.addLabels(associatedLabels);
+    }
+    return issue;
+  };
 
   const checkIsAuthor = (issue, loggedUserId) => {
     if (issue.authorId === loggedUserId) {
@@ -210,6 +230,8 @@ const IssueService = ({
     getIssueList,
     getIssue,
     registerIssue,
+    updateMilestone,
+    updateLabels,
     updateTitle,
     updateContents,
     updateAssignees,


### PR DESCRIPTION
이슈 수정 API를 5개로 분리하여 구현했습니다.

- /issues/:id/title : Title 수정 API
- /issues/:id/contents : Contents 수정 API
- /issues/:id/milestone : Milestone 수정 API
- /issues/:id/labels : Labels 수정 API
- /issues/:id/assignees : Assignees 수정 API

### 확인할 부분

이슈에 대한 서비스 로직을 처리하는 IssueService 모듈의 크기가 너무 커진 것 같은데 이슈의 동작별로 서비스 로직을 분리해서 별도의 파일로 만드는 것은 어떨지 의견 부탁드립니다. 

예시)
- IssueCreateService
- IssueReadService
- IssueUpdateService