### PR TITLE
Fix: 마일스톤 API 미동작 오류 수정

### DIFF
--- a/server/src/services/milestone.js
+++ b/server/src/services/milestone.js
@@ -1,13 +1,6 @@
 const MilestoneService = ({ MilestoneModel, sequelize }) => {
   const query = (isClosed) => {
-    return `(
-    SELECT COUNT(*)
-    FROM issues AS issue
-    WHERE
-        issue.milestone_id = milestone.id
-        AND
-        issue.is_closed = ${isClosed}
-    )`;
+    return `(SELECT COUNT(*) FROM issues AS issue WHERE issue.milestone_id = milestone.id AND issue.is_closed = ${isClosed})`;
   };
   const getMilestoneList = async () => {
     const milestones = await MilestoneModel.findAll({


### PR DESCRIPTION
마일스톤 리스트를 불러오는 서비스로직에서 사용한 쿼리문이 가독성에 좋게 라인을 나눠서 작성되어 있는데 이 쿼리문을 babel로 번들링 했을때 newline 문자가 포함되면서 쿼리가 동작하지 않던 문제를 발견하고 수정함.

**수정전**
```javascript
  const query = (isClosed) => {
    return `(
    SELECT COUNT(*)
    FROM issues AS issue
    WHERE
        issue.milestone_id = milestone.id
        AND
        issue.is_closed = ${isClosed}
    )`;
  };
```

**수정후**
```javascript
const query = (isClosed) => {
    return `(SELECT COUNT(*) FROM issues AS issue WHERE issue.milestone_id = milestone.id AND issue.is_closed = ${isClosed})`;
  };
```